### PR TITLE
dropping zope.component

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,11 @@ CHANGES
 4.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Dropped the dependency on ``zope.component`` as the interface and
+  implementation of ``ObjectEvent`` is now in ``zope.interface``.
+  Retained the dependency for the tests.
+
+- ...
 
 
 4.0.2 (2013-03-08)

--- a/setup.py
+++ b/setup.py
@@ -59,10 +59,9 @@ setup(
     include_package_data=True,
     install_requires=['setuptools',
                       'zope.interface',
-                      'zope.component',
                       'zope.event'],
     extras_require=dict(
-        test = []
+        test = ['zope.component']
         ),
     test_suite='zope.lifecycleevent.tests.test_suite',
     zip_safe=False,

--- a/src/zope/lifecycleevent/__init__.py
+++ b/src/zope/lifecycleevent/__init__.py
@@ -15,7 +15,7 @@
 """
 __docformat__ = 'restructuredtext'
 
-from zope.component.interfaces import ObjectEvent
+from zope.interface.interfaces import ObjectEvent
 from zope.interface import implementer, moduleProvides
 from zope.event import notify
 
@@ -37,15 +37,16 @@ moduleProvides(IZopeLifecycleEvent)
 class ObjectCreatedEvent(ObjectEvent):
     """An object has been created"""
 
+
 def created(object):
     notify(ObjectCreatedEvent(object))
 
 
 @implementer(IAttributes)
-class Attributes(object) :
+class Attributes(object):
     """Describes modified attributes of an interface."""
 
-    def __init__(self, interface, *attributes) :
+    def __init__(self, interface, *attributes):
         self.interface = interface
         self.attributes = attributes
 
@@ -54,16 +55,16 @@ class Attributes(object) :
 class Sequence(object):
     """Describes modified keys of an interface."""
 
-    def __init__(self, interface, *keys) :
+    def __init__(self, interface, *keys):
         self.interface = interface
         self.keys = keys
+
 
 @implementer(IObjectModifiedEvent)
 class ObjectModifiedEvent(ObjectEvent):
     """An object has been modified"""
 
-
-    def __init__(self, object, *descriptions) :
+    def __init__(self, object, *descriptions):
         """Init with a list of modification descriptions."""
         super(ObjectModifiedEvent, self).__init__(object)
         self.descriptions = descriptions
@@ -77,7 +78,6 @@ def modified(object, *descriptions):
 class ObjectCopiedEvent(ObjectCreatedEvent):
     """An object has been copied"""
 
-
     def __init__(self, object, original):
         super(ObjectCopiedEvent, self).__init__(object)
         self.original = original
@@ -90,7 +90,6 @@ def copied(object, original):
 @implementer(IObjectMovedEvent)
 class ObjectMovedEvent(ObjectEvent):
     """An object has been moved"""
-
 
     def __init__(self, object, oldParent, oldName, newParent, newName):
         ObjectEvent.__init__(self, object)
@@ -108,7 +107,6 @@ def moved(object, oldParent, oldName, newParent, newName):
 class ObjectAddedEvent(ObjectMovedEvent):
     """An object has been added to a container"""
 
-
     def __init__(self, object, newParent=None, newName=None):
         if newParent is None:
             newParent = object.__parent__
@@ -124,7 +122,6 @@ def added(object, newParent=None, newName=None):
 @implementer(IObjectRemovedEvent)
 class ObjectRemovedEvent(ObjectMovedEvent):
     """An object has been removed from a container"""
-
 
     def __init__(self, object, oldParent=None, oldName=None):
         if oldParent is None:

--- a/src/zope/lifecycleevent/interfaces.py
+++ b/src/zope/lifecycleevent/interfaces.py
@@ -16,7 +16,7 @@
 __docformat__ = 'restructuredtext'
 
 from zope.interface import Interface, Attribute
-import zope.component.interfaces
+from zope.interface import interfaces
 
 
 class IZopeLifecycleEvent(Interface):
@@ -70,7 +70,7 @@ class IZopeLifecycleEvent(Interface):
         """
 
 
-class IObjectCreatedEvent(zope.component.interfaces.IObjectEvent):
+class IObjectCreatedEvent(interfaces.IObjectEvent):
     """An object has been created.
 
     The location will usually be ``None`` for this event."""
@@ -82,17 +82,17 @@ class IObjectCopiedEvent(IObjectCreatedEvent):
     original = Attribute("The original from which the copy was made")
 
 
-class IObjectModifiedEvent(zope.component.interfaces.IObjectEvent):
+class IObjectModifiedEvent(interfaces.IObjectEvent):
     """An object has been modified"""
 
 
-class IModificationDescription(Interface) :
+class IModificationDescription(Interface):
     """ Marker interface for descriptions of object modifications.
 
     Can be used as a parameter of an IObjectModifiedEvent."""
 
 
-class IAttributes(IModificationDescription) :
+class IAttributes(IModificationDescription):
     """ Describes the attributes of an interface.
 
     """
@@ -101,7 +101,7 @@ class IAttributes(IModificationDescription) :
     attributes = Attribute("A sequence of modified attributes.")
 
 
-class ISequence(IModificationDescription) :
+class ISequence(IModificationDescription):
     """ Describes the modified keys of a sequence-like interface.
 
     """
@@ -113,7 +113,7 @@ class ISequence(IModificationDescription) :
 ##############################################################################
 # Moving Objects
 
-class IObjectMovedEvent(zope.component.interfaces.IObjectEvent):
+class IObjectMovedEvent(interfaces.IObjectEvent):
     """An object has been moved."""
 
     oldParent = Attribute("The old location parent for the object.")

--- a/src/zope/lifecycleevent/tests.py
+++ b/src/zope/lifecycleevent/tests.py
@@ -24,9 +24,12 @@ from zope.lifecycleevent import ObjectCopiedEvent, copied
 
 
 class TestSequence(unittest.TestCase):
+
     def testSequence(self):
+
         from zope.interface import Interface, Attribute
-        class ISample(Interface) :
+
+        class ISample(Interface):
             field1 = Attribute("A test field")
             field2 = Attribute("A test field")
             field3 = Attribute("A test field")
@@ -96,11 +99,11 @@ class TestObjectModifiedEvent(unittest.TestCase):
     def testAttributes(self):
         from zope.interface import implementer, Interface, Attribute
 
-        class ISample(Interface) :
+        class ISample(Interface):
             field = Attribute("A test field")
 
         @implementer(ISample)
-        class Sample(object) :
+        class Sample(object):
             pass
         obj = Sample()
         obj.field = 42
@@ -168,8 +171,8 @@ class TestObjectMovedEvent(unittest.TestCase):
         from zope.interface.verify import verifyObject
         from zope.lifecycleevent.interfaces import IObjectMovedEvent
         verifyObject(IObjectMovedEvent,
-                     self._makeOne(None, None, None, None, None)
-                    )
+                     self._makeOne(None, None, None, None, None))
+
 
 class TestObjectAddedEvent(unittest.TestCase):
 
@@ -214,6 +217,7 @@ class TestObjectAddedEvent(unittest.TestCase):
         ob = Context()
         verifyObject(IObjectAddedEvent, self._makeOne(ob, parent, 'new_name'))
 
+
 class TestObjectRemovedEvent(unittest.TestCase):
 
     def _getTargetClass(self):
@@ -257,8 +261,10 @@ class TestObjectRemovedEvent(unittest.TestCase):
         ob = object()
         verifyObject(IObjectRemovedEvent, self._makeOne(ob, parent, 'new_name'))
 
+
 class Context:
     pass
+
 
 def test_suite():
     return unittest.TestSuite((
@@ -274,5 +280,5 @@ def test_suite():
                              tearDown=zope.component.testing.tearDown),
         ))
 
-if __name__=='__main__':
+if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')


### PR DESCRIPTION
Dropped the dependency on `zope.component` as the interface and implementation of `ObjectEvent` is now in `zope.interface`.  Retained the dependency for the tests.
