### PR TITLE
Add Python 3.6 and enable coverage reporting for tox and coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = zope.lifecycleevent
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,6 @@ develop-eggs
 parts
 doc/_build
 .coverage
+.coverage.*
+coverage.xml
 htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: python
 sudo: false
 python:
-    - 2.7
-    - 3.3
-    - 3.4
-    - 3.5
-    - pypy
-    - pypy3.3-5.2-alpha1
-install:
-    - pip install -U pip setuptools # need updated pip for caching
-    - pip install .[test]
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - pypy-5.6.0
+  - pypy3.3-5.5-alpha
 script:
-    - python -m zope.lifecycleevent.tests
+  - coverage run -m zope.testrunner --test-path=src
+
+after_success:
+  - coveralls
 notifications:
-    email: false
+  email: false
+
+install:
+  - pip install -U pip setuptools
+  - pip install -U coveralls coverage
+  - pip install -U -e ".[test]"
+
 
 cache: pip
+
+before_cache:
+  - rm -f $HOME/.cache/pip/log/debug.log

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,18 @@
-Changes
-=======
+=========
+ Changes
+=========
+
 
 4.2.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6.
+- Drop support for Python 2.6 and 3.3.
 
 
 4.1.0 (2014-12-27)
-------------------
+==================
 
 - Add support for PyPy3.
 
@@ -18,7 +20,7 @@ Changes
 
 
 4.0.3 (2013-09-12)
-------------------
+==================
 
 - Drop the dependency on ``zope.component`` as the interface and
   implementation of ``ObjectEvent`` is now in ``zope.interface``.
@@ -28,19 +30,19 @@ Changes
 
 
 4.0.2 (2013-03-08)
-------------------
+==================
 
 - Add Trove classifiers indicating CPython and PyPy support.
 
 
 4.0.1 (2013-02-11)
-------------------
+==================
 
 - Add `tox.ini`.
 
 
 4.0.0 (2013-02-11)
-------------------
+==================
 
 - Test coverage at 100%.
 
@@ -53,30 +55,30 @@ Changes
 
 
 3.7.0 (2011-03-17)
-------------------
+==================
 
 - Add convenience functions to parallel ``zope.lifecycleevent.modified``
   for the other events defined in this package.
 
 
 3.6.2 (2010-09-25)
-------------------
+==================
 
 - Add not declared, but needed test dependency on ``zope.component [test]``.
 
 3.6.1 (2010-04-30)
-------------------
+==================
 
 - Remove dependency on undeclared ``zope.testing.doctest``.
 
 3.6.0 (2009-12-29)
-------------------
+==================
 
 - Refactor tests to lose ``zope.annotation`` and ``zope.dublincore`` as
   dependencies.
 
 3.5.2 (2009-05-17)
-------------------
+==================
 
 - Copy ``IObjectMovedEvent``, ``IObjectAddedEvent``,
   ``IObjectRemovedEvent`` interfaces and ``ObjectMovedEvent``,
@@ -87,7 +89,7 @@ Changes
   ``zope.container`` (which has many).
 
 3.5.1 (2009-03-09)
-------------------
+==================
 
 - Remove deprecated code and therefore dependency on ``zope.deferredimport``.
 
@@ -97,13 +99,13 @@ Changes
 - Update package's description and documentation.
 
 3.5.0 (2009-01-31)
-------------------
+==================
 
 - Remove old module declarations from classes.
 
 - Use ``zope.container`` instead of ``zope.app.container``.
 
 3.4.0 (2007-09-01)
-------------------
+==================
 
 Initial release as an independent package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,12 @@
 include *.rst
 include *.txt
+include .travis.yml
+include .coveragerc
 include tox.ini
 include bootstrap.py
 include buildout.cfg
 
 recursive-include src *
+recursive-include doc *.rst *.py Makefile
 
 global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
-``zope.lifecycleevent``
-=======================
+=========================
+ ``zope.lifecycleevent``
+=========================
 
 .. image:: https://travis-ci.org/zopefoundation/zope.lifecycleevent.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.lifecycleevent

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read(*rnames):
 setup(
     name='zope.lifecycleevent',
     version=read('version.txt').strip(),
-    url='http://pypi.python.org/pypi/zope.lifecycleevent',
+    url='http://github.com/zopefoundation/zope.lifecycleevent',
     author='Zope Foundation and Contributors',
     author_email='zope-dev@zope.org',
     license='ZPL 2.1',
@@ -40,31 +40,36 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Operating System :: OS Independent',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development',
-        ],
+    ],
     description='Object life-cycle events',
     long_description=\
         read('README.rst')
         + '\n\n' +
         read('CHANGES.rst'),
-
+    keywords="event lifecycle zope component interface flexible",
     packages=find_packages('src'),
     package_dir={'': 'src'},
     namespace_packages=['zope',],
     include_package_data=True,
-    install_requires=['setuptools',
-                      'zope.interface',
-                      'zope.event'],
-    extras_require=dict(
-        test = ['zope.component']
-        ),
+    install_requires=[
+        'setuptools',
+        'zope.interface',
+        'zope.event'
+    ],
+    extras_require={
+        'test': [
+            'zope.component',
+            'zope.testrunner',
+        ],
+    },
     test_suite='zope.lifecycleevent.tests.test_suite',
     zip_safe=False,
-    )
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,22 @@
 [tox]
-envlist =
-    py27,py33,py34,py35,pypy,pypy3
+envlist = py27,py34,py35,py36,pypy
 
 [testenv]
 commands =
-    python setup.py -q test -q
-# without explicit deps, setup.py test will download a bunch of eggs into $PWD
+    coverage run -m zope.testrunner --test-path=src []
 deps =
-    zope.interface
-    zope.component
-    zope.event
+    .[test]
+    coverage
+setenv =
+   COVERAGE_FILE=.coverage.{envname}
 
 [testenv:coverage]
-basepython =
-    python2.7
+setenv =
+  COVERAGE_FILE=.coverage
+skip_install = true
 commands =
-#   The installed version messes up nose's test discovery / coverage reporting
-#   So, we uninstall that from the environment, and then install the editable
-#   version, before running nosetests.
-    pip uninstall -y zope.lifecycleevent
-    pip install -e .
-    nosetests --with-xunit --with-xcoverage
-deps =
-    nose
-    coverage
-    nosexcover
+    coverage erase
+    coverage combine
+    coverage report
+    coverage html
+    coverage xml


### PR DESCRIPTION
Fixes #8

Reach 100% test coverage and simplify the test structure to combine many common tests and fixtures.

Also some minor project janitoring.